### PR TITLE
msm8916: Stop building generic charger images

### DIFF
--- a/product/charger.mk
+++ b/product/charger.mk
@@ -1,3 +1,0 @@
-# Charger
-PRODUCT_PACKAGES += \
-    charger_res_images


### PR DESCRIPTION
CM now builds this by default in vendor/cm.

Change-Id: Idfa80434075818fb02eff8ba1ac33556608ed636